### PR TITLE
Use global DOCUMENT_ROOT to find scss file.

### DIFF
--- a/SassPlugin.php
+++ b/SassPlugin.php
@@ -20,7 +20,7 @@ class SassPlugin extends BasePlugin
 
     public function getVersion()
     {
-        return '1.0';
+        return '1.0.1';
     }
 
     public function getDeveloper()

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "imarc/craft-sass",
     "description": "A Craft plugin that compiles SASS on the server as needed.",
     "homepage": "https://github.com/imarc/craft-sass",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "type": "library",
     "license": "Apache",
     "authors": [

--- a/services/Sass_CompilerService.php
+++ b/services/Sass_CompilerService.php
@@ -47,7 +47,7 @@ class Sass_CompilerService extends BaseApplicationComponent
      */
     public function compile($filename)
     {
-        $document_root = dirname(craft()->request->getScriptFile());
+        $document_root = $_SERVER['DOCUMENT_ROOT'];
 
         $filename = realpath("$document_root/$filename");
 


### PR DESCRIPTION
With localized sites, the dirname of the script file can contain a locale string, i.e. /de or /es. This means that the global scss file cannot be found and is not compiled. Having the path be appended to the environment's docroot seems to be a simpler and more universal choice. If you can think of a way to do this without using the Global variable, then let's do that instead of this PR.
